### PR TITLE
Added single-target variant to /bal

### DIFF
--- a/src/main/java/dev/elrol/serverutilities/commands/BalCmd.java
+++ b/src/main/java/dev/elrol/serverutilities/commands/BalCmd.java
@@ -33,6 +33,8 @@ extends _CmdBase {
             if(name.isEmpty()) name = a;
             dispatcher.register((Commands.literal(a)
                     .executes(this::execute))
+                    .then(Commands.argument("player", EntityArgument.player())
+                            .executes(c -> other(c, List.of(EntityArgument.getPlayer(c, "player")))))
                     .then(Commands.argument("players", EntityArgument.players())
                             .executes(c -> other(c, EntityArgument.getPlayers(c, "players")))));
         }


### PR DESCRIPTION
This will allow the single-target and multi-target variants to have different permission nodes, allowing the potentially laggy multi-target variant to be restricted to server staff.