### PR TITLE
Added 1.19.3 event workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ org.gradle.daemon=false
 modId = elrolsutilities
 modGroup = dev.elrol.serverutilities
 modFileName = Server_Utils
-modVersion = 2.8.8-0297-1
+modVersion = 2.9.1-beta.1
 modMinecraftVersion = 1.19.2
 modForgeVersion = 43.1.32

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ org.gradle.daemon=false
 modId = elrolsutilities
 modGroup = dev.elrol.serverutilities
 modFileName = Server_Utils
-modVersion = 2.8.8b5
+modVersion = 2.8.8-0297-1
 modMinecraftVersion = 1.19.2
 modForgeVersion = 43.1.32

--- a/src/main/java/dev/elrol/serverutilities/Main.java
+++ b/src/main/java/dev/elrol/serverutilities/Main.java
@@ -94,7 +94,7 @@ public class Main {
 
         loadKits();
 
-        MinecraftForge.EVENT_BUS.register(new ChatEventHandler());
+        ChatEventHandler.registerChatHandler();
         MinecraftForge.EVENT_BUS.register(new EntityEventHandler());
         MinecraftForge.EVENT_BUS.register(new LivingDropHandler());
 


### PR DESCRIPTION
This is disgusting but it works to make us compatible with both versions despite differences in available classes